### PR TITLE
Fix max_results parameter, was not working before

### DIFF
--- a/duckduckgo_images_api/api.py
+++ b/duckduckgo_images_api/api.py
@@ -67,8 +67,8 @@ def search(keywords: str, max_results=None) -> Dict:
         logger.debug("Hitting Url Success : %s", requestUrl)
         printJson(data["results"])
 
-        if "next" not in data:
-            logger.debug("No Next Page - Exiting")
+        if "next" not in data or (max_results is not None and len(data["results"]) >= max_results):
+            logger.debug("No Next Page or max_results exceeded - Exiting")
             return data
 
         requestUrl = url + data["next"]


### PR DESCRIPTION
`max_results` was ignored before, now it is checked in every iteration before making a new HTTPS call.

This significantly speeds up the search when `max_results` is not `None`. For example 100. Coming from 4s to 0.5s:

Before:
<img width="926" alt="image" src="https://user-images.githubusercontent.com/985581/163785538-7c0323eb-bb04-459c-93b7-3562dab41d0e.png">

After (with `max_results = 10`):
<img width="916" alt="image" src="https://user-images.githubusercontent.com/985581/163785553-551d1907-ea2f-404f-8a6b-6d2d0393aaff.png">
